### PR TITLE
docs: convert to archive style

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | :warning: | This project is no longer being maintained. Please use [contributte/event-dispatcher-extra](https://github.com/contributte/event-dispatcher-extra).
 |---|---|
 
-| Composer | [`contributte/event-bridges`](https://packagist.org/packages/contributte/event-bridges) |
+| Composer | [`contributte/event-bridges`](https://packagist.org/contributte/event-bridges) |
 |---| --- |
 | Version | ![](https://badgen.net/packagist/v/contributte/event-bridges) |
 | PHP | ![](https://badgen.net/packagist/php/contributte/event-bridges) |
@@ -31,7 +31,7 @@ Collection of Nette bridges to [`Contributte\EventDispatcher`](https://github.co
 
 ## Development
 
-This package was maintain by these authors.
+This package was maintained by these authors.
 
 <a href="https://github.com/f3l1x">
   <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">
@@ -40,4 +40,4 @@ This package was maintain by these authors.
 -----
 
 Consider to [support](https://contributte.org/partners.html) **contributte** development team.
-Also thank you for being used this package.
+Also thank you for using this package.


### PR DESCRIPTION
This PR converts the README to the proper archive style following the template.

## Changes Made

- Fixed Composer package URL (removed `/packages/` from Packagist URL)
- Fixed grammar: "was maintain" → "was maintained"
- Fixed grammar: "for being used" → "for using"

All changes align with the archive template to ensure consistency across archived Contributte repositories.

The README already had:
- Deprecation badge with `?deprecated=1` parameter
- Disclaimer section with warning emoji
- Composer package info table with badges
- Replacement package reference (contributte/event-dispatcher-extra)
- Past tense Development section

This ensures the repository is properly formatted before archival.